### PR TITLE
Support customization "ssl_protocols" to enable TLSv1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,10 @@ Values : *yes* | *no*
 Default value : *yes*  
 If set to yes, nginx will use HTTP2 protocol when HTTPS is enabled.  
 
+`HTTPS_PROTOCOLS`  
+Values : *TLSv1.2* | *TLSv1.3* | *TLSv1.2 TLSv1.3*  
+Default value : *TLSv1.2 TLSv1.3*  
+
 ## ModSecurity
 
 `USE_MODSECURITY`  

--- a/confs/https.conf
+++ b/confs/https.conf
@@ -1,7 +1,7 @@
 listen 0.0.0.0:8443 ssl %HTTP2%;
 ssl_certificate %HTTPS_CERT%;
 ssl_certificate_key %HTTPS_KEY%;
-ssl_protocols TLSv1.3;
+ssl_protocols %HTTPS_PROTOCOLS%;
 ssl_prefer_server_ciphers off;
 ssl_session_tickets off;
 %STRICT_TRANSPORT_SECURITY%

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,6 +84,7 @@ BLOCK_PROXIES="${BLOCK_PROXIES-yes}"
 BLOCK_ABUSERS="${BLOCK_ABUSERS-yes}"
 AUTO_LETS_ENCRYPT="${AUTO_LETS_ENCRYPT-no}"
 HTTP2="${HTTP2-yes}"
+HTTPS_PROTOCOLS="${HTTPS_PROTOCOLS-TLSv1.3}"
 STRICT_TRANSPORT_SECURITY="${STRICT_TRANSPORT_SECURITY-max-age=31536000}"
 USE_MODSECURITY="${USE_MODSECURITY-yes}"
 USE_MODSECURITY_CRS="${USE_MODSECURITY_CRS-yes}"
@@ -260,6 +261,11 @@ if [ "$AUTO_LETS_ENCRYPT" = "yes" ] || [ "$USE_CUSTOM_HTTPS" = "yes" ] || [ "$GE
 		replace_in_file "/etc/nginx/https.conf" "%HTTP2%" "http2"
 	else
 		replace_in_file "/etc/nginx/https.conf" "%HTTP2%" ""
+	fi
+	if [ "$HTTPS_PROTOCOLS" != "" ] ; then
+		replace_in_file "/etc/nginx/https.conf" "%HTTPS_PROTOCOLS%" "$HTTPS_PROTOCOLS"
+	else
+		replace_in_file "/etc/nginx/https.conf" "%HTTPS_PROTOCOLS%" ""
 	fi
 	if [ "$STRICT_TRANSPORT_SECURITY" != "" ] ; then
 		replace_in_file "/etc/nginx/https.conf" "%STRICT_TRANSPORT_SECURITY%" "more_set_headers 'Strict-Transport-Security: $STRICT_TRANSPORT_SECURITY';"


### PR DESCRIPTION
- Added "HTTPS_PROTOCOLS" environment value to enable to customize TLS version. default value is "TLSv1.2 TLSv1.3". (because sometimes TLSv1.2  needed)
- READMD.md