### PR TITLE
Log and log format directives override allowed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apk --no-cache add certbot libstdc++ libmaxminddb geoip pcre yajl fail2ban c
     touch /var/log/nginx/error.log /var/log/nginx/modsec_audit.log && \
     chown nginx:nginx /var/log/nginx/*.log
 
-VOLUME /www /http-confs /server-confs /modsec-confs /modsec-crs-confs
+VOLUME /www /http-confs /server-confs /modsec-confs /modsec-crs-confs /logs-confs
 
 EXPOSE 8080/tcp 8443/tcp
 

--- a/README.md
+++ b/README.md
@@ -701,8 +701,14 @@ ENV USE_ANTIBOT captcha
 Custom configurations files (ending with .conf suffix) can be added in some directory inside the container :
   - /http-confs : http context
   - /server-confs : server context
+  - /logs-confs : server log directives to override confs/log-format.conf.default
 
 You just need to use a volume like this :
 ```
-docker run ... -v /path/to/http/confs:/http-confs ... -v /path/to/server/confs:/server-confs ... bunkerity/bunkerized-nginx
+docker run ... \
+           -v /path/to/http/confs:/http-confs \
+           -v /path/to/server/confs:/server-confs \
+           -v /path/to/log/confs:/log-confs \
+           ... \
+           bunkerity/bunkerized-nginx
 ```

--- a/confs/log-format.conf.default
+++ b/confs/log-format.conf.default
@@ -1,0 +1,2 @@
+access_log syslog:server=unix:/dev/log,nohostname,facility=local0,severity=notice combined;
+error_log syslog:server=unix:/dev/log,nohostname,facility=local0 warn;

--- a/confs/nginx.conf
+++ b/confs/nginx.conf
@@ -52,8 +52,8 @@ http {
 	client_max_body_size %MAX_CLIENT_SIZE%;
 
 	# write logs to local syslog
-	access_log syslog:server=unix:/dev/log,nohostname,facility=local0,severity=notice combined;
-	error_log syslog:server=unix:/dev/log,nohostname,facility=local0 warn;
+	# override http confs
+	include /logs-confs/*.conf;
 
 	# temp paths
 	proxy_temp_path /tmp/proxy_temp;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,9 @@ function spaces_to_lua() {
 
 # copy stub confs
 cp /opt/confs/* /etc/nginx
+if [ ! -f /logs-confs/custom-log-format.conf ] ; then
+	cp /opt/confs/log-format.conf.default /logs-confs/log-format.conf
+fi
 cp /opt/logs/rsyslog.conf /etc/rsyslog.conf
 cp /opt/logs/logrotate.conf /etc/logrotate.conf
 cp -r /opt/lua/* /usr/local/lib/lua

--- a/examples/log-format-override/docker-compose.yml
+++ b/examples/log-format-override/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+
+  mylog:
+    # image: bunkerity/bunkerized-nginx
+    image: solidginx
+    restart: always
+    ports:
+      - 80:8080
+      - 443:8443
+    volumes:
+      - ./log-confs:/logs-confs
+      - ./web-files:/www
+    environment:
+      - SERVER_NAME=app1.website.com app2.website.com # replace with your domains
+      - SERVE_FILES=yes
+      - DISABLE_DEFAULT_SERVER=no
+      - REDIRECT_HTTP_TO_HTTPS=no
+      - AUTO_LETS_ENCRYPT=no
+      - USE_FAIL2BAN=no
+      - USE_CLAMAV_SCAN=no
+      - USE_CLAMAV_UPLOAD=no

--- a/examples/log-format-override/log-confs/custom-log-format.conf
+++ b/examples/log-format-override/log-confs/custom-log-format.conf
@@ -1,0 +1,7 @@
+log_format newformat '$remote_addr - $host - $remote_user [$time_local] '
+                       '"$request" $status $bytes_sent '
+                       '"$http_referer" "$http_user_agent"';
+
+
+access_log syslog:server=unix:/dev/log,facility=local0,severity=notice newformat;
+error_log syslog:server=unix:/dev/log,nohostname,facility=local0 warn;

--- a/examples/log-format-override/web-files/index.html
+++ b/examples/log-format-override/web-files/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+    <html lang="en">
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        (＾º◡º＾❁)<!-- meow -->
+    </body>
+</html>


### PR DESCRIPTION
Hi,

in order to change the nginx log format, I've moved the log directives to a default configuration file.

One can now mount the /logs-confs volume to override the default config, and therefore set a custom log format or log destination.

The example shows how to add the $host variable to the access log, in order to make it display the domain name a request was for.