### PR TITLE
incorrect variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ Default value : *yes*
 Context : *global*, *multisite*  
 When set to *yes*, the *secure* will be automatically added to cookies when using HTTPS.
 
-`STRICT_TRANSPORT_POLICY`  
+`STRICT_TRANSPORT_SECURITY`  
 Values : *max-age=expireTime [; includeSubDomains] [; preload]*  
 Default value : *max-age=31536000*  
 Context : *global*, *multisite*  


### PR DESCRIPTION
Incorrect variable naming: changed `STRICT_TRANSPORT_POLICY` to `STRICT_TRANSPORT_SECURITY`.